### PR TITLE
Fix problem with using class Base which is not yet required

### DIFF
--- a/lib/xing_api_client/call/users_contacts_shared_call.rb
+++ b/lib/xing_api_client/call/users_contacts_shared_call.rb
@@ -1,3 +1,5 @@
+require_relative 'base'
+
 class XingApiClient
   module Call
     module UsersContactsSharedCall


### PR DESCRIPTION
Hi, I don't know if this is the recommended way of doing this, but this solved require problems on my Linux. The problem seems to be in the order which ruby loads files from the directory.

Rgds,
jablan
